### PR TITLE
Adds line to remove collation from dump before importing

### DIFF
--- a/.lagoon/scripts/polydock_post_deploy.sh
+++ b/.lagoon/scripts/polydock_post_deploy.sh
@@ -31,6 +31,8 @@ if [ ! -f "$LOCKFILE" ]; then
   cd /app
 
   if [ -f "$POLYDOCK_APP_IMAGE_DB_FILENAME" ]; then
+    echo "Removing collation from DB ..."                                                                                                                                                     
+    sed -i 's/COLLATE=utf8mb4_uca1400_ai_ci //g' $POLYDOCK_APP_IMAGE_DB_FILENAME
     echo "Loading database image"
     cat $POLYDOCK_APP_IMAGE_DB_FILENAME | drush sql-cli
     echo "Database image loaded"


### PR DESCRIPTION
This pull request introduces a change to the post-deployment script that improves database compatibility by removing a specific collation setting before loading the database image. This helps prevent issues related to unsupported or problematic collations during the database import process.

**Database compatibility improvement:**

* In `.lagoon/scripts/polydock_post_deploy.sh`, added a step to remove `COLLATE=utf8mb4_uca1400_ai_ci` from the database dump file using `sed` before loading it into the database.